### PR TITLE
Write-Verbose : Cannot bind argument to parameter 'Message' because it is null

### DIFF
--- a/Set-SqlStartupParameters.ps1
+++ b/Set-SqlStartupParameters.ps1
@@ -10,7 +10,14 @@ function Set-SQLStartupParameters{
     #Loop through and change instances
     foreach($i in $Instance){
         #Parse host and instance names
-        $HostName = ($i.Split('\'))[0]
+        if (($i.Split('\').count) -gt 1)
+            {
+            $HostName = ($i.Split('\'))[0]
+            }
+        else
+            {
+            $HostName = $i
+            }
         $InstanceName = ($i.Split('\'))[1]
 
         #Get service account names, set service account for change


### PR DESCRIPTION
Fixed issue where default instance failed as the name would be truncated after the first character.  Once this was done the code properly updates the startup parameters.

Here is the error I got::

`PS> Set-SQLStartupParameters "localhost" "-T1499"
Write-Verbose : Cannot bind argument to parameter 'Message' because it is null.
At line:22 char:23
+         Write-Verbose $wmisvc.StartupParameters
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Write-Verbose], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.WriteVerbos
   eCommand

Exception calling "Substring" with "2" argument(s): "Index and length must refer to a location within the string.
Parameter name: length"
At line:38 char:50
+ ... ms += $oldparams | Where-Object {$_.Substring(0,2) -match '-d|-e|-l'}
+                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : ArgumentOutOfRangeException

Exception setting "StartupParameters": "STARTUPPARAMETERS: unknown property."
At line:46 char:13
+             $wmisvc.StartupParameters = $paramstring
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], SetValueInvocationException
    + FullyQualifiedErrorId : ExceptionWhenSetting

WARNING: Startup Parameters for localhost updated. You will need to restart the service for these changes to take
effect.
PS>`